### PR TITLE
Fix prediction breaking when angled.

### DIFF
--- a/lua/entities/cfc_trampoline/shared.lua
+++ b/lua/entities/cfc_trampoline/shared.lua
@@ -48,6 +48,7 @@ function ENT.bouncePlayer( trampoline, ply, plyPhys, speed )
     local bounceMult = isHoldingJump and BOUNCE_MULT_JUMPING:GetFloat() or BOUNCE_MULT:GetFloat()
     local bounceSpeed = math.min( speed * bounceMult, BOUNCE_MAX:GetFloat() )
     local up = trampoline:GetUp()
+    local appliedVelocity = up * bounceSpeed
 
     local isUnfrozen = SERVER and trampoline:GetPhysicsObject():IsMotionEnabled() or false
     if isUnfrozen then
@@ -55,9 +56,6 @@ function ENT.bouncePlayer( trampoline, ply, plyPhys, speed )
         -- Raphael: This breaks prediction. Is this really needed?
         plyPhys:SetPos( plyPhys:GetPos() + up * 5 )
     end
-
-    local appliedVelocity = up * bounceSpeed
-    ply:SetVelocity( appliedVelocity )
 
     if SERVER then
     	SOUND_FILTER:RemoveAllPlayers()


### PR DESCRIPTION
The SetVelocity call broke prediction, and it gave you additional velocity which was noticeable when the trampoline was angled.

So now with it removed, you don't have any prediction errors, and it seems to work perfectly.

https://github.com/CFC-Servers/cfc_bouncy_circle/assets/64648134/6e84ad01-c802-4b4a-81ff-304417bef015

